### PR TITLE
Enhance gallery UI: larger navigation arrows and more homepage photos

### DIFF
--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -256,7 +256,7 @@ function Lightbox(props: {
             </button>
           </div>
           <Show when={exifParts().length > 0}>
-            <div class="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-center text-xs text-white bg-black/60 rounded px-2 py-1">
+            <div class="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-center text-xs text-white bg-black/60 rounded-full px-4 py-2">
               {exifParts().join(' • ')}
             </div>
           </Show>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -256,7 +256,7 @@ function Lightbox(props: {
             </button>
           </div>
           <Show when={exifParts().length > 0}>
-            <div class="absolute bottom-4 left-4 right-4 text-center text-xs text-white bg-black/60 rounded px-3 py-2">
+            <div class="absolute bottom-4 left-1/2 transform -translate-x-1/2 text-center text-xs text-white bg-black/60 rounded px-2 py-1">
               {exifParts().join(' • ')}
             </div>
           </Show>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -238,7 +238,7 @@ function Lightbox(props: {
           <div class="absolute inset-y-0 left-0 flex items-center">
             <button
               onClick={(e) => { e.stopPropagation(); props.onPrev(); }}
-              class="m-2 bg-black/50 hover:bg-black/70 text-white rounded-full p-3"
+              class="m-2 bg-black/50 hover:bg-black/70 text-white rounded-full p-6 text-2xl"
               aria-label="Previous photo"
               data-no-drag
             >
@@ -248,7 +248,7 @@ function Lightbox(props: {
           <div class="absolute inset-y-0 right-0 flex items-center">
             <button
               onClick={(e) => { e.stopPropagation(); props.onNext(); }}
-              class="m-2 bg-black/50 hover:bg-black/70 text-white rounded-full p-3"
+              class="m-2 bg-black/50 hover:bg-black/70 text-white rounded-full p-6 text-2xl"
               aria-label="Next photo"
               data-no-drag
             >

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -256,7 +256,7 @@ function Lightbox(props: {
             </button>
           </div>
           <Show when={exifParts().length > 0}>
-            <div class="absolute bottom-4 left-4 right-4 text-center text-xs text-gray-400">
+            <div class="absolute bottom-4 left-4 right-4 text-center text-xs text-white bg-black/60 rounded px-3 py-2">
               {exifParts().join(' • ')}
             </div>
           </Show>

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -255,14 +255,11 @@ function Lightbox(props: {
               ›
             </button>
           </div>
-          <div class="absolute bottom-2 left-2 right-2 text-center text-sm text-gray-300">
-            <div class="mb-1">{photo().alt}</div>
-            <Show when={exifParts().length > 0}>
-              <div class="text-xs text-gray-400">
-                {exifParts().join(' • ')}
-              </div>
-            </Show>
-          </div>
+          <Show when={exifParts().length > 0}>
+            <div class="absolute bottom-4 left-4 right-4 text-center text-xs text-gray-400">
+              {exifParts().join(' • ')}
+            </div>
+          </Show>
         </div>
       </div>
     </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -83,7 +83,7 @@ export default function Home() {
 
         <section class="px-4 py-8">
           <h2 class="text-xl text-gray-200 mb-4">Recent work</h2>
-          <Gallery photos={safeList().slice(0, 6)} />
+          <Gallery photos={safeList().slice(0, 9)} />
           <div class="text-center mt-6">
             <a href="/photos" class="text-accent-400 hover:text-accent-300 font-medium">See full gallery →</a>
           </div>


### PR DESCRIPTION
- Double the size of lightbox navigation arrows for better usability
- Increase homepage gallery from 6 to 9 photos for richer preview