### PR TITLE
Add hidden hand theremin page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "optimize:photos:1080p": "MAX_WIDTH=1920 MAX_HEIGHT=1080 QUALITY=80 node scripts/optimize-images.mjs"
   },
   "dependencies": {
+    "@mediapipe/tasks-vision": "^0.10.35",
     "@solidjs/router": "^0.16.1",
     "@tailwindcss/typography": "^0.5.16",
     "@vercel/analytics": "^1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mediapipe/tasks-vision':
+        specifier: ^0.10.35
+        version: 0.10.35
       '@solidjs/router':
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.11)
@@ -295,6 +298,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mediapipe/tasks-vision@0.10.35':
+    resolution: {integrity: sha512-HOvadwVRE6JC+45nyYhmnywnr5h/J8KZvOeUNVOG9q/0875pZgItznFB9bRTvLc264YSJqiZ1NsIpCStJw/egg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -880,8 +886,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001684:
-    resolution: {integrity: sha512-G1LRwLIQjBQoyq0ZJGqGIJUXzJ8irpbjHLpVRXDvBEScFJ9b17sgK6vlx0GAJFE21okD7zXl08rRRUfq6HdoEQ==}
+  caniuse-lite@1.0.30001784:
+    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1816,6 +1822,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@mediapipe/tasks-vision@0.10.35': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2113,7 +2121,7 @@ snapshots:
   autoprefixer@10.4.20(postcss@8.5.8):
     dependencies:
       browserslist: 4.24.2
-      caniuse-lite: 1.0.30001684
+      caniuse-lite: 1.0.30001784
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
@@ -2150,7 +2158,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001684
+      caniuse-lite: 1.0.30001784
       electron-to-chromium: 1.5.65
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -2159,7 +2167,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001684: {}
+  caniuse-lite@1.0.30001784: {}
 
   chokidar@3.6.0:
     dependencies:

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -12,6 +12,7 @@ import Home from "~/routes/index";
 import SinglePhotoPage from "~/routes/photo/[id]";
 import PhotosPage from "~/routes/photos/index";
 import SynthPage from "~/routes/synth";
+import ThereminPage from "~/routes/theremin";
 import Homepage3 from "~/routes/homepage3";
 
 import "./app.css";
@@ -36,6 +37,7 @@ export default function App() {
       <Route path="/blog/:slug" component={BlogPost} />
       <Route path="/about" component={About} />
       <Route path="/synth" component={SynthPage} />
+      <Route path="/theremin" component={ThereminPage} />
       <Route path="/homepage3" component={Homepage3} />
       <Route path="*404" component={NotFound} />
     </Router>

--- a/src/lib/handRing.ts
+++ b/src/lib/handRing.ts
@@ -1,0 +1,89 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface RingNote {
+  note: string;
+  frequency: number;
+}
+
+export interface RingLayout {
+  id: "left" | "right";
+  label: string;
+  center: Point;
+  innerRadius: number;
+  outerRadius: number;
+  notes: RingNote[];
+}
+
+export interface RingHit {
+  ringId: RingLayout["id"];
+  note: RingNote;
+  sectorIndex: number;
+  distance: number;
+  angle: number;
+}
+
+export const CHROMATIC_NOTES = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+] as const;
+
+const A4_FREQUENCY = 440;
+const A4_MIDI = 69;
+
+const noteToMidi = (noteIndex: number, octave: number) => (octave + 1) * 12 + noteIndex;
+
+const midiToFrequency = (midi: number) =>
+  Number((A4_FREQUENCY * 2 ** ((midi - A4_MIDI) / 12)).toFixed(2));
+
+export const createChromaticScale = (octave: number): RingNote[] =>
+  CHROMATIC_NOTES.map((note, index) => ({
+    note: `${note}${octave}`,
+    frequency: midiToFrequency(noteToMidi(index, octave)),
+  }));
+
+export const getRingHit = (point: Point, ring: RingLayout): RingHit | null => {
+  const dx = point.x - ring.center.x;
+  const dy = point.y - ring.center.y;
+  const distance = Math.hypot(dx, dy);
+
+  if (distance < ring.innerRadius || distance > ring.outerRadius) {
+    return null;
+  }
+
+  const angle = (Math.atan2(dy, dx) + Math.PI / 2 + Math.PI * 2) % (Math.PI * 2);
+  const sectorIndex = Math.floor((angle / (Math.PI * 2)) * ring.notes.length) % ring.notes.length;
+
+  return {
+    ringId: ring.id,
+    note: ring.notes[sectorIndex],
+    sectorIndex,
+    distance,
+    angle,
+  };
+};
+
+export const getNoteLabelPosition = (
+  ring: RingLayout,
+  sectorIndex: number,
+  radius = (ring.innerRadius + ring.outerRadius) / 2,
+): Point => {
+  const angle = (sectorIndex + 0.5) * ((Math.PI * 2) / ring.notes.length) - Math.PI / 2;
+
+  return {
+    x: ring.center.x + Math.cos(angle) * radius,
+    y: ring.center.y + Math.sin(angle) * radius,
+  };
+};

--- a/src/lib/handRingAudio.ts
+++ b/src/lib/handRingAudio.ts
@@ -1,0 +1,103 @@
+import type { RingNote } from "~/lib/handRing";
+
+type BrowserWindow = Window &
+  typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext;
+  };
+
+class RingVoice {
+  private oscillator: OscillatorNode;
+  private gain: GainNode;
+  private activeNote: RingNote | null = null;
+
+  constructor(
+    private context: AudioContext,
+    destination: AudioNode,
+    detune: number,
+  ) {
+    this.oscillator = context.createOscillator();
+    this.gain = context.createGain();
+
+    this.oscillator.type = "sine";
+    this.oscillator.detune.value = detune;
+    this.gain.gain.value = 0;
+    this.oscillator.connect(this.gain);
+    this.gain.connect(destination);
+    this.oscillator.start();
+  }
+
+  play(note: RingNote) {
+    if (this.activeNote?.note === note.note) return;
+
+    const now = this.context.currentTime;
+    this.activeNote = note;
+    this.oscillator.frequency.cancelScheduledValues(now);
+    this.oscillator.frequency.setTargetAtTime(note.frequency, now, 0.015);
+    this.gain.gain.cancelScheduledValues(now);
+    this.gain.gain.setTargetAtTime(0.18, now, 0.025);
+  }
+
+  stop() {
+    if (!this.activeNote) return;
+
+    const now = this.context.currentTime;
+    this.activeNote = null;
+    this.gain.gain.cancelScheduledValues(now);
+    this.gain.gain.setTargetAtTime(0, now, 0.04);
+  }
+
+  dispose() {
+    this.stop();
+
+    const stopAt = this.context.currentTime + 0.08;
+    this.oscillator.stop(stopAt);
+    this.oscillator.disconnect();
+    this.gain.disconnect();
+  }
+}
+
+export class HandRingAudio {
+  private context: AudioContext;
+  private masterGain: GainNode;
+  private leftVoice: RingVoice;
+  private rightVoice: RingVoice;
+
+  constructor() {
+    const AudioContextCtor =
+      window.AudioContext ?? (window as BrowserWindow).webkitAudioContext;
+
+    if (!AudioContextCtor) {
+      throw new Error("Web Audio is not supported in this browser.");
+    }
+
+    this.context = new AudioContextCtor();
+    this.masterGain = this.context.createGain();
+    this.masterGain.gain.value = 0.75;
+    this.masterGain.connect(this.context.destination);
+    this.leftVoice = new RingVoice(this.context, this.masterGain, -5);
+    this.rightVoice = new RingVoice(this.context, this.masterGain, 5);
+  }
+
+  async resume() {
+    if (this.context.state !== "running") {
+      await this.context.resume();
+    }
+  }
+
+  play(ringId: "left" | "right", note: RingNote) {
+    const voice = ringId === "left" ? this.leftVoice : this.rightVoice;
+    voice.play(note);
+  }
+
+  stop(ringId: "left" | "right") {
+    const voice = ringId === "left" ? this.leftVoice : this.rightVoice;
+    voice.stop();
+  }
+
+  dispose() {
+    this.leftVoice.dispose();
+    this.rightVoice.dispose();
+    this.masterGain.disconnect();
+    void this.context.close();
+  }
+}

--- a/src/routes/theremin.tsx
+++ b/src/routes/theremin.tsx
@@ -27,6 +27,11 @@ interface ActiveRingHit {
   hit: RingHit;
 }
 
+interface FingerPoint {
+  id: string;
+  point: Point;
+}
+
 const clamp = (value: number, min: number, max: number) =>
   Math.min(Math.max(value, min), max);
 
@@ -73,13 +78,13 @@ const createHandLandmarker = async () => {
   return HandLandmarker.createFromOptions(vision, {
     baseOptions: {
       modelAssetPath: HAND_MODEL_URL,
-      delegate: "GPU",
+      delegate: "CPU",
     },
     runningMode: "VIDEO",
     numHands: 2,
-    minHandDetectionConfidence: 0.55,
-    minHandPresenceConfidence: 0.55,
-    minTrackingConfidence: 0.55,
+    minHandDetectionConfidence: 0.35,
+    minHandPresenceConfidence: 0.35,
+    minTrackingConfidence: 0.35,
   });
 };
 
@@ -98,6 +103,8 @@ export default function ThereminPage() {
   const [status, setStatus] = createSignal("Start the camera, then move an index finger into a note ring.");
   const [stageSize, setStageSize] = createSignal({ width: 1280, height: 720 });
   const [activeHits, setActiveHits] = createSignal(createEmptyHits());
+  const [detectedFingers, setDetectedFingers] = createSignal<FingerPoint[]>([]);
+  const [trackingSummary, setTrackingSummary] = createSignal("No hands detected yet.");
 
   const rings = createMemo<RingLayout[]>(() => {
     const { width, height } = stageSize();
@@ -159,6 +166,8 @@ export default function ThereminPage() {
     videoStream = null;
     lastVideoTime = -1;
     setActiveHits(createEmptyHits());
+    setDetectedFingers([]);
+    setTrackingSummary("No hands detected yet.");
     setIsRunning(false);
   };
 
@@ -169,12 +178,15 @@ export default function ThereminPage() {
 
     const stageRect = stageRef.getBoundingClientRect();
     const nextHits = createEmptyHits();
+    const nextFingers: FingerPoint[] = [];
 
-    for (const landmarks of result.landmarks) {
+    result.landmarks.forEach((landmarks, handIndex) => {
       const indexTip = landmarks[8];
-      if (!indexTip) continue;
+      if (!indexTip) return;
 
       const point = getVideoPoint(indexTip, videoRef, stageRect);
+      nextFingers.push({ id: `hand-${handIndex}`, point });
+
       const hits = rings()
         .map((ring) => ({ ring, hit: getRingHit(point, ring) }))
         .filter((entry): entry is { ring: RingLayout; hit: RingHit } => entry.hit !== null)
@@ -184,7 +196,7 @@ export default function ThereminPage() {
       if (match) {
         nextHits[match.ring.id] = { point, hit: match.hit };
       }
-    }
+    });
 
     (["left", "right"] as const).forEach((ringId) => {
       const active = nextHits[ringId];
@@ -196,6 +208,14 @@ export default function ThereminPage() {
     });
 
     setActiveHits(nextHits);
+    setDetectedFingers(nextFingers);
+    setTrackingSummary(
+      nextFingers.length === 0
+        ? "No hands detected. Keep both hands visible and well lit."
+        : `${nextFingers.length} hand${nextFingers.length === 1 ? "" : "s"} detected. ${
+            Object.values(nextHits).filter(Boolean).length
+          } ring${Object.values(nextHits).filter(Boolean).length === 1 ? "" : "s"} playing.`,
+    );
   };
 
   const runDetectionLoop = () => {
@@ -242,7 +262,7 @@ export default function ThereminPage() {
 
       setStatus("Loading hand tracker...");
       handLandmarker = await createHandLandmarker();
-      setStatus("Move either index finger into a ring to play.");
+      setStatus("Tracking is running. Move both index fingertips onto the note rings.");
       setIsRunning(true);
       runDetectionLoop();
     } catch (error) {
@@ -374,11 +394,31 @@ export default function ThereminPage() {
                 );
               }}
             </For>
+            <For each={detectedFingers()}>
+              {(finger) => (
+                <g>
+                  <circle
+                    cx={finger.point.x}
+                    cy={finger.point.y}
+                    r="18"
+                    fill="rgba(212,158,8,0.16)"
+                    stroke="rgba(255,240,209,0.7)"
+                    stroke-width="2"
+                  />
+                  <circle cx={finger.point.x} cy={finger.point.y} r="4" fill="#FFF0D1" />
+                </g>
+              )}
+            </For>
           </svg>
 
           <section class="absolute left-1/2 top-24 z-10 w-[min(92vw,34rem)] -translate-x-1/2 rounded-2xl border border-superbock-400/20 bg-surface/72 px-5 py-4 text-center shadow-2xl backdrop-blur-md">
             <p class="font-serif text-2xl font-bold tracking-tight text-bacalhau">Hand Theremin</p>
             <p class="mt-2 text-sm leading-6 text-bacalhau-200">{status()}</p>
+            <Show when={isRunning()}>
+              <p class="mt-1 text-xs uppercase tracking-[0.18em] text-superbock-300">
+                {trackingSummary()}
+              </p>
+            </Show>
             <div class="mt-4 flex flex-wrap items-center justify-center gap-3">
               <button
                 type="button"

--- a/src/routes/theremin.tsx
+++ b/src/routes/theremin.tsx
@@ -1,0 +1,413 @@
+import type {
+  HandLandmarker as HandLandmarkerInstance,
+  HandLandmarkerResult,
+  NormalizedLandmark,
+} from "@mediapipe/tasks-vision";
+import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+
+import {
+  createChromaticScale,
+  getNoteLabelPosition,
+  getRingHit,
+  type Point,
+  type RingHit,
+  type RingLayout,
+} from "~/lib/handRing";
+import { HandRingAudio } from "~/lib/handRingAudio";
+
+const MEDIAPIPE_VERSION = "0.10.35";
+const WASM_BASE_URL = `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@${MEDIAPIPE_VERSION}/wasm`;
+const HAND_MODEL_URL =
+  "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/latest/hand_landmarker.task";
+
+type RingId = RingLayout["id"];
+
+interface ActiveRingHit {
+  point: Point;
+  hit: RingHit;
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+const createEmptyHits = (): Record<RingId, ActiveRingHit | null> => ({
+  left: null,
+  right: null,
+});
+
+const getVideoPoint = (
+  landmark: NormalizedLandmark,
+  video: HTMLVideoElement,
+  stage: DOMRect,
+): Point => {
+  const videoAspect = video.videoWidth / video.videoHeight;
+  const stageAspect = stage.width / stage.height;
+
+  if (!Number.isFinite(videoAspect) || videoAspect === 0) {
+    return { x: (1 - landmark.x) * stage.width, y: landmark.y * stage.height };
+  }
+
+  if (videoAspect > stageAspect) {
+    const renderedWidth = stage.height * videoAspect;
+    const offsetX = (stage.width - renderedWidth) / 2;
+
+    return {
+      x: offsetX + (1 - landmark.x) * renderedWidth,
+      y: landmark.y * stage.height,
+    };
+  }
+
+  const renderedHeight = stage.width / videoAspect;
+  const offsetY = (stage.height - renderedHeight) / 2;
+
+  return {
+    x: (1 - landmark.x) * stage.width,
+    y: offsetY + landmark.y * renderedHeight,
+  };
+};
+
+const createHandLandmarker = async () => {
+  const { FilesetResolver, HandLandmarker } = await import("@mediapipe/tasks-vision");
+  const vision = await FilesetResolver.forVisionTasks(WASM_BASE_URL);
+
+  return HandLandmarker.createFromOptions(vision, {
+    baseOptions: {
+      modelAssetPath: HAND_MODEL_URL,
+      delegate: "GPU",
+    },
+    runningMode: "VIDEO",
+    numHands: 2,
+    minHandDetectionConfidence: 0.55,
+    minHandPresenceConfidence: 0.55,
+    minTrackingConfidence: 0.55,
+  });
+};
+
+export default function ThereminPage() {
+  let stageRef: HTMLDivElement | undefined;
+  let videoRef: HTMLVideoElement | undefined;
+  let animationFrame = 0;
+  let videoStream: MediaStream | null = null;
+  let handLandmarker: HandLandmarkerInstance | null = null;
+  let audio: HandRingAudio | null = null;
+  let lastVideoTime = -1;
+
+  const [isClient, setIsClient] = createSignal(false);
+  const [isStarting, setIsStarting] = createSignal(false);
+  const [isRunning, setIsRunning] = createSignal(false);
+  const [status, setStatus] = createSignal("Start the camera, then move an index finger into a note ring.");
+  const [stageSize, setStageSize] = createSignal({ width: 1280, height: 720 });
+  const [activeHits, setActiveHits] = createSignal(createEmptyHits());
+
+  const rings = createMemo<RingLayout[]>(() => {
+    const { width, height } = stageSize();
+    const outerRadius = clamp(Math.min(width * 0.2, height * 0.27), 70, 190);
+    const innerRadius = outerRadius * 0.45;
+    const centerY = height * 0.55;
+
+    return [
+      {
+        id: "left",
+        label: "Low hand",
+        center: { x: width * 0.28, y: centerY },
+        innerRadius,
+        outerRadius,
+        notes: createChromaticScale(3),
+      },
+      {
+        id: "right",
+        label: "High hand",
+        center: { x: width * 0.72, y: centerY },
+        innerRadius,
+        outerRadius,
+        notes: createChromaticScale(4),
+      },
+    ];
+  });
+
+  onMount(() => {
+    setIsClient(true);
+
+    if (!stageRef) return;
+
+    const updateStageSize = () => {
+      const rect = stageRef?.getBoundingClientRect();
+      if (!rect) return;
+      setStageSize({ width: rect.width, height: rect.height });
+    };
+
+    updateStageSize();
+
+    const observer = new ResizeObserver(updateStageSize);
+    observer.observe(stageRef);
+    onCleanup(() => observer.disconnect());
+  });
+
+  const stopEverything = () => {
+    if (animationFrame) {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = 0;
+    }
+
+    audio?.stop("left");
+    audio?.stop("right");
+    audio?.dispose();
+    audio = null;
+    handLandmarker?.close();
+    handLandmarker = null;
+    videoStream?.getTracks().forEach((track) => track.stop());
+    videoStream = null;
+    lastVideoTime = -1;
+    setActiveHits(createEmptyHits());
+    setIsRunning(false);
+  };
+
+  onCleanup(stopEverything);
+
+  const applyFrameResult = (result: HandLandmarkerResult) => {
+    if (!stageRef || !videoRef || !audio) return;
+
+    const stageRect = stageRef.getBoundingClientRect();
+    const nextHits = createEmptyHits();
+
+    for (const landmarks of result.landmarks) {
+      const indexTip = landmarks[8];
+      if (!indexTip) continue;
+
+      const point = getVideoPoint(indexTip, videoRef, stageRect);
+      const hits = rings()
+        .map((ring) => ({ ring, hit: getRingHit(point, ring) }))
+        .filter((entry): entry is { ring: RingLayout; hit: RingHit } => entry.hit !== null)
+        .sort((a, b) => a.hit.distance - b.hit.distance);
+
+      const match = hits.find(({ ring }) => nextHits[ring.id] === null);
+      if (match) {
+        nextHits[match.ring.id] = { point, hit: match.hit };
+      }
+    }
+
+    (["left", "right"] as const).forEach((ringId) => {
+      const active = nextHits[ringId];
+      if (active) {
+        audio?.play(ringId, active.hit.note);
+      } else {
+        audio?.stop(ringId);
+      }
+    });
+
+    setActiveHits(nextHits);
+  };
+
+  const runDetectionLoop = () => {
+    if (!videoRef || !handLandmarker) return;
+
+    if (videoRef.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA && videoRef.currentTime !== lastVideoTime) {
+      lastVideoTime = videoRef.currentTime;
+      const result = handLandmarker.detectForVideo(videoRef, performance.now());
+      applyFrameResult(result);
+    }
+
+    animationFrame = requestAnimationFrame(runDetectionLoop);
+  };
+
+  const startTheremin = async () => {
+    if (isRunning() || isStarting()) return;
+
+    try {
+      setIsStarting(true);
+      setStatus("Requesting camera access...");
+
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error("This browser does not support camera access.");
+      }
+
+      if (!videoRef) {
+        throw new Error("Video element is not ready yet.");
+      }
+
+      audio = new HandRingAudio();
+      await audio.resume();
+
+      videoStream = await navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: "user",
+          width: { ideal: 1280 },
+          height: { ideal: 720 },
+        },
+        audio: false,
+      });
+
+      videoRef.srcObject = videoStream;
+      await videoRef.play();
+
+      setStatus("Loading hand tracker...");
+      handLandmarker = await createHandLandmarker();
+      setStatus("Move either index finger into a ring to play.");
+      setIsRunning(true);
+      runDetectionLoop();
+    } catch (error) {
+      stopEverything();
+      setStatus(error instanceof Error ? error.message : "Could not start the theremin.");
+    } finally {
+      setIsStarting(false);
+    }
+  };
+
+  return (
+    <main class="min-h-screen bg-surface text-bacalhau overflow-hidden">
+      <Show
+        when={isClient()}
+        fallback={
+          <div class="min-h-screen flex items-center justify-center">
+            <span class="text-sm uppercase tracking-[0.2em] text-vinho-300">Initializing...</span>
+          </div>
+        }
+      >
+        <div
+          ref={stageRef}
+          class="relative h-screen w-screen overflow-hidden bg-surface"
+          aria-label="Hidden hand controlled theremin"
+        >
+          <video
+            ref={videoRef}
+            class="absolute inset-0 h-full w-full object-cover opacity-55 scale-x-[-1]"
+            autoplay
+            muted
+            playsinline
+          />
+
+          <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(212,158,8,0.08),rgba(26,15,20,0.72)_62%,rgba(26,15,20,0.94))]" />
+
+          <svg
+            class="absolute inset-0 h-full w-full"
+            viewBox={`0 0 ${stageSize().width} ${stageSize().height}`}
+            role="img"
+            aria-label="Two circular note rings"
+          >
+            <For each={rings()}>
+              {(ring) => {
+                const active = () => activeHits()[ring.id];
+
+                return (
+                  <g>
+                    <circle
+                      cx={ring.center.x}
+                      cy={ring.center.y}
+                      r={ring.outerRadius}
+                      fill="rgba(89,37,50,0.24)"
+                      stroke={active() ? "rgba(212,158,8,0.92)" : "rgba(255,240,209,0.32)"}
+                      stroke-width="2"
+                    />
+                    <circle
+                      cx={ring.center.x}
+                      cy={ring.center.y}
+                      r={ring.innerRadius}
+                      fill="rgba(26,15,20,0.68)"
+                      stroke="rgba(255,240,209,0.2)"
+                      stroke-width="1"
+                    />
+                    <For each={ring.notes}>
+                      {(note, index) => {
+                        const labelPoint = () => getNoteLabelPosition(ring, index());
+                        const linePoint = () => getNoteLabelPosition(ring, index(), ring.outerRadius);
+                        const activeNote = () => active()?.hit.note.note === note.note;
+
+                        return (
+                          <g>
+                            <line
+                              x1={ring.center.x}
+                              y1={ring.center.y}
+                              x2={linePoint().x}
+                              y2={linePoint().y}
+                              stroke="rgba(255,240,209,0.12)"
+                              stroke-width="1"
+                            />
+                            <text
+                              x={labelPoint().x}
+                              y={labelPoint().y}
+                              text-anchor="middle"
+                              dominant-baseline="middle"
+                              fill={activeNote() ? "#D49E08" : "rgba(255,240,209,0.76)"}
+                              font-size={activeNote() ? "18" : "14"}
+                              font-weight={activeNote() ? "700" : "500"}
+                            >
+                              {note.note.replace(/\d$/, "")}
+                            </text>
+                          </g>
+                        );
+                      }}
+                    </For>
+                    <text
+                      x={ring.center.x}
+                      y={ring.center.y - 8}
+                      text-anchor="middle"
+                      fill="rgba(255,240,209,0.78)"
+                      font-size="13"
+                      font-weight="700"
+                      letter-spacing="2"
+                    >
+                      {ring.label}
+                    </text>
+                    <text
+                      x={ring.center.x}
+                      y={ring.center.y + 16}
+                      text-anchor="middle"
+                      fill={active() ? "#D49E08" : "rgba(255,240,209,0.48)"}
+                      font-size="20"
+                      font-weight="700"
+                    >
+                      {active()?.hit.note.note ?? "REST"}
+                    </text>
+                    <Show when={active()}>
+                      {(activeHit) => (
+                        <circle
+                          cx={activeHit().point.x}
+                          cy={activeHit().point.y}
+                          r="10"
+                          fill="#D49E08"
+                          stroke="#FFF0D1"
+                          stroke-width="2"
+                        />
+                      )}
+                    </Show>
+                  </g>
+                );
+              }}
+            </For>
+          </svg>
+
+          <section class="absolute left-1/2 top-24 z-10 w-[min(92vw,34rem)] -translate-x-1/2 rounded-2xl border border-superbock-400/20 bg-surface/72 px-5 py-4 text-center shadow-2xl backdrop-blur-md">
+            <p class="font-serif text-2xl font-bold tracking-tight text-bacalhau">Hand Theremin</p>
+            <p class="mt-2 text-sm leading-6 text-bacalhau-200">{status()}</p>
+            <div class="mt-4 flex flex-wrap items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={startTheremin}
+                disabled={isStarting() || isRunning()}
+                class="rounded-full bg-superbock-400 px-5 py-2 text-sm font-bold uppercase tracking-[0.18em] text-vinho-950 transition hover:bg-superbock-300 disabled:cursor-not-allowed disabled:opacity-55"
+              >
+                {isStarting() ? "Starting..." : isRunning() ? "Running" : "Start"}
+              </button>
+              <Show when={isRunning()}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    stopEverything();
+                    setStatus("Stopped. Start again when you want to play.");
+                  }}
+                  class="rounded-full border border-bacalhau-200/30 px-5 py-2 text-sm font-bold uppercase tracking-[0.18em] text-bacalhau-100 transition hover:border-superbock-400/70 hover:text-superbock-400"
+                >
+                  Stop
+                </button>
+              </Show>
+            </div>
+          </section>
+
+          <div class="pointer-events-none absolute bottom-8 left-1/2 z-10 w-[min(92vw,42rem)] -translate-x-1/2 rounded-full border border-bacalhau-100/10 bg-surface/55 px-5 py-3 text-center text-xs uppercase tracking-[0.2em] text-bacalhau-200 backdrop-blur-md">
+            Index finger in the ring plays notes. Center and outside the ring are silent.
+          </div>
+        </div>
+      </Show>
+    </main>
+  );
+}

--- a/src/routes/theremin.tsx
+++ b/src/routes/theremin.tsx
@@ -43,31 +43,40 @@ const createEmptyHits = (): Record<RingId, ActiveRingHit | null> => ({
 const getVideoPoint = (
   landmark: NormalizedLandmark,
   video: HTMLVideoElement,
-  stage: DOMRect,
+  stageRect: DOMRect,
 ): Point => {
+  const videoRect = video.getBoundingClientRect();
   const videoAspect = video.videoWidth / video.videoHeight;
-  const stageAspect = stage.width / stage.height;
+  const elementAspect = videoRect.width / videoRect.height;
 
   if (!Number.isFinite(videoAspect) || videoAspect === 0) {
-    return { x: (1 - landmark.x) * stage.width, y: landmark.y * stage.height };
-  }
-
-  if (videoAspect > stageAspect) {
-    const renderedWidth = stage.height * videoAspect;
-    const offsetX = (stage.width - renderedWidth) / 2;
-
     return {
-      x: offsetX + (1 - landmark.x) * renderedWidth,
-      y: landmark.y * stage.height,
+      x: videoRect.left - stageRect.left + (1 - landmark.x) * videoRect.width,
+      y: videoRect.top - stageRect.top + landmark.y * videoRect.height,
     };
   }
 
-  const renderedHeight = stage.width / videoAspect;
-  const offsetY = (stage.height - renderedHeight) / 2;
+  const content =
+    videoAspect > elementAspect
+      ? {
+          width: videoRect.height * videoAspect,
+          height: videoRect.height,
+          x: (videoRect.width - videoRect.height * videoAspect) / 2,
+          y: 0,
+        }
+      : {
+          width: videoRect.width,
+          height: videoRect.width / videoAspect,
+          x: 0,
+          y: (videoRect.height - videoRect.width / videoAspect) / 2,
+        };
+
+  const unmirroredX = content.x + landmark.x * content.width;
+  const mirroredX = videoRect.width - unmirroredX;
 
   return {
-    x: (1 - landmark.x) * stage.width,
-    y: offsetY + landmark.y * renderedHeight,
+    x: videoRect.left - stageRect.left + mirroredX,
+    y: videoRect.top - stageRect.top + content.y + landmark.y * content.height,
   };
 };
 

--- a/src/routes/theremin.tsx
+++ b/src/routes/theremin.tsx
@@ -71,8 +71,7 @@ const getVideoPoint = (
           y: (videoRect.height - videoRect.width / videoAspect) / 2,
         };
 
-  const unmirroredX = content.x + landmark.x * content.width;
-  const mirroredX = videoRect.width - unmirroredX;
+  const mirroredX = content.x + (1 - landmark.x) * content.width;
 
   return {
     x: videoRect.left - stageRect.left + mirroredX,


### PR DESCRIPTION
## Summary
- Adds a hidden `/theremin` route that is registered in the router but not linked from site navigation.
- Uses MediaPipe hand landmarks to map index fingertips onto two circular chromatic note rings.
- Adds Web Audio helper voices with ramped note changes for discrete theremin-like playback.

## Test plan
- `pnpm check`
- `pnpm build`
- Browser verification of `/theremin`: page rendered with no console errors; Start button initiated camera access. Full camera/audio interaction requires local camera permission.


Made with [Cursor](https://cursor.com)