### PR TITLE
Fix theremin dot alignment with reactive stage sizing

### DIFF
--- a/src/routes/theremin.tsx
+++ b/src/routes/theremin.tsx
@@ -3,7 +3,7 @@ import type {
   HandLandmarkerResult,
   NormalizedLandmark,
 } from "@mediapipe/tasks-vision";
-import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js";
 
 import {
   createChromaticScale,
@@ -97,7 +97,6 @@ const createHandLandmarker = async () => {
 };
 
 export default function ThereminPage() {
-  let stageRef: HTMLDivElement | undefined;
   let videoRef: HTMLVideoElement | undefined;
   let animationFrame = 0;
   let videoStream: MediaStream | null = null;
@@ -113,6 +112,7 @@ export default function ThereminPage() {
   const [activeHits, setActiveHits] = createSignal(createEmptyHits());
   const [detectedFingers, setDetectedFingers] = createSignal<FingerPoint[]>([]);
   const [trackingSummary, setTrackingSummary] = createSignal("No hands detected yet.");
+  const [stageElement, setStageElement] = createSignal<HTMLDivElement>();
 
   const rings = createMemo<RingLayout[]>(() => {
     const { width, height } = stageSize();
@@ -142,19 +142,21 @@ export default function ThereminPage() {
 
   onMount(() => {
     setIsClient(true);
+  });
 
-    if (!stageRef) return;
+  createEffect(() => {
+    const element = stageElement();
+    if (!element) return;
 
     const updateStageSize = () => {
-      const rect = stageRef?.getBoundingClientRect();
-      if (!rect) return;
+      const rect = element.getBoundingClientRect();
       setStageSize({ width: rect.width, height: rect.height });
     };
 
     updateStageSize();
 
     const observer = new ResizeObserver(updateStageSize);
-    observer.observe(stageRef);
+    observer.observe(element);
     onCleanup(() => observer.disconnect());
   });
 
@@ -182,9 +184,10 @@ export default function ThereminPage() {
   onCleanup(stopEverything);
 
   const applyFrameResult = (result: HandLandmarkerResult) => {
-    if (!stageRef || !videoRef || !audio) return;
+    const stage = stageElement();
+    if (!stage || !videoRef || !audio) return;
 
-    const stageRect = stageRef.getBoundingClientRect();
+    const stageRect = stage.getBoundingClientRect();
     const nextHits = createEmptyHits();
     const nextFingers: FingerPoint[] = [];
 
@@ -292,7 +295,9 @@ export default function ThereminPage() {
         }
       >
         <div
-          ref={stageRef}
+          ref={(element) => {
+            setStageElement(element);
+          }}
           class="relative h-screen w-screen overflow-hidden bg-surface"
           aria-label="Hidden hand controlled theremin"
         >


### PR DESCRIPTION
## Summary
- Make theremin stage sizing reactive to the mounted stage element instead of relying on a non-reactive ref.
- Keep SVG `viewBox` and hand landmark projection in the same coordinate space so fingertip dots align with the mirrored camera feed.
- Use the same reactive stage element when computing frame mapping bounds during hand tracking.

## Test plan
- [x] Run `pnpm dev` and open `/theremin`.
- [x] Start camera tracking and move index fingers across the rings.
- [x] Verify fingertip dots now follow real hand positions without the rightward offset.

Made with [Cursor](https://cursor.com)